### PR TITLE
security: restrict abis in bitcoind.service

### DIFF
--- a/contrib/init/bitcoind.service
+++ b/contrib/init/bitcoind.service
@@ -81,5 +81,8 @@ PrivateDevices=true
 # Deny the creation of writable and executable memory mappings.
 MemoryDenyWriteExecute=true
 
+# Restrict ABIs to help ensure MemoryDenyWriteExecute is enforced
+SystemCallArchitectures=native
+
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
[As noted here](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#MemoryDenyWriteExecute=), it's a good idea pair `MemoryDenyWriteExecute=true` with `SystemCallArchitectures=native`.
This helps restrict the possible application binary interfaces (ABIs) that can be used when running bitcoind through systemd, reducing the attack surface area.